### PR TITLE
increase max payload size to 250MB

### DIFF
--- a/src/compiler/createWebSocketServer.js
+++ b/src/compiler/createWebSocketServer.js
@@ -42,7 +42,7 @@ module.exports = function createWebSocketServer() {
   const webSocketServer = new Server({
     server: httpServer,
     perMessageDeflate: false,
-    maxPayload: 200 * 1024 * 1024,
+    maxPayload: 250 * 1024 * 1024,
   });
 
   httpServer.listen(socketAddress);


### PR DESCRIPTION
I dug into the websocket lib and added some extra debug to the error and found this:

`Error: max payload size exceeded 215999979 > 209715200`

So it is actually getting a payload size that is above the maximum. Re-reading the issue on this in the Haul repo I found: https://github.com/callstack/haul/pull/434#issuecomment-391264657 Basically something to do with this returning a serialized buffer balloons the payload size beyond that of the actual file size.

Lastly, once I got it working, here is the size reported from the ios build from haul:

`200 GET /index.bundle  76135801b`

This size and that of the payload correlate closely to what the person reported in that issue.

The million dollar question is still... why is this only on my machine? No clue.